### PR TITLE
feat(remind): remindコマンドを管理者と投稿者が実行できるように変更

### DIFF
--- a/src/commands/remindCommand.ts
+++ b/src/commands/remindCommand.ts
@@ -72,7 +72,7 @@ export const remindCommandHandler: Command = {
 			return;
 		}
 
-		// 管理者権限チェック
+		// 権限チェック
 		const isAdmin = interaction.memberPermissions?.has(PermissionFlagsBits.Administrator);
 		const isSender = interaction.user.id === message.author.id;
 

--- a/src/commands/remindCommand.ts
+++ b/src/commands/remindCommand.ts
@@ -47,7 +47,9 @@ export const remindCommandHandler: Command = {
 		}
 
 		// 管理者権限チェック
-		if (!interaction.memberPermissions?.has(PermissionFlagsBits.Administrator)) {
+		const isAdmin = interaction.memberPermissions?.has(PermissionFlagsBits.Administrator)
+
+		if (!isAdmin) {
 			sendResponse(
 				interaction,
 				buildErrorEmbed("このコマンドを実行するには管理者権限が必要です。"),

--- a/src/commands/remindCommand.ts
+++ b/src/commands/remindCommand.ts
@@ -46,17 +46,6 @@ export const remindCommandHandler: Command = {
 			console.error("Failed to defer reply:", error);
 		}
 
-		// 管理者権限チェック
-		const isAdmin = interaction.memberPermissions?.has(PermissionFlagsBits.Administrator)
-
-		if (!isAdmin) {
-			sendResponse(
-				interaction,
-				buildErrorEmbed("このコマンドを実行するには管理者権限が必要です。"),
-			);
-			return;
-		}
-
 		// メッセージIDの取得
 		const messageId = interaction.options.getString("message_id");
 		if (!messageId) {
@@ -79,6 +68,18 @@ export const remindCommandHandler: Command = {
 				buildErrorEmbed(
 					"指定されたメッセージが存在しないか、読み取り権限の無いチャンネルのメッセージです。",
 				),
+			);
+			return;
+		}
+
+		// 管理者権限チェック
+		const isAdmin = interaction.memberPermissions?.has(PermissionFlagsBits.Administrator);
+		const isSender = interaction.user.id === message.author.id;
+
+		if (!isAdmin && !isSender) {
+			sendResponse(
+				interaction,
+				buildErrorEmbed("このコマンドを実行するには管理者またはメッセージの投稿者である必要があります。"),
 			);
 			return;
 		}


### PR DESCRIPTION
## 目的

remindコマンドを管理者だけでなく、メッセージの投稿者もできるようにする

## 実装内容

- 権限チェックでユーザーとメッセージの投稿者のIDの一致の確認を追加